### PR TITLE
Move media upload location logic to the server

### DIFF
--- a/apps/web/alinea.config.tsx
+++ b/apps/web/alinea.config.tsx
@@ -31,6 +31,7 @@ const web = workspace('Alinea', {
   typeNamespace: 'content',
   source: './content',
   mediaDir: './public',
+  mediaUrl: (location: string) => location.slice('public'.length),
   color: '#4a65e8',
   roots: {
     data: root('Alinea website', {

--- a/apps/web/src/pages/[...slug].tsx
+++ b/apps/web/src/pages/[...slug].tsx
@@ -1,7 +1,7 @@
-import {backend} from '@alinea/content/backend.js'
+import {initPages} from '@alinea/content/web/pages.js'
 
 export async function getStaticPaths() {
-  const pages = backend.loadPages('web')
+  const pages = initPages()
   const urls = await pages
     .where(page => page.type.isIn(['Doc']))
     .select(page => page.url)

--- a/packages/backend/src/Data.ts
+++ b/packages/backend/src/Data.ts
@@ -32,7 +32,7 @@ export namespace Data {
   }
 
   export interface Media {
-    upload(params: Hub.UploadParams, ctx: Hub.Context): Promise<string>
+    upload(params: Hub.MediaUploadParams, ctx: Hub.Context): Promise<string>
     download(
       params: Hub.DownloadParams,
       ctx: Hub.Context

--- a/packages/backend/src/Storage.ts
+++ b/packages/backend/src/Storage.ts
@@ -19,7 +19,7 @@ export namespace Storage {
     extension: string
   ) {
     const isIndex = entry.path === '' || entry.path === 'index'
-    return entry.url + (isIndex ? '/index' : '') + extension
+    return (entry.url + (isIndex ? '/index' : '') + extension).toLowerCase()
   }
 
   export async function publishChanges(

--- a/packages/backend/test/TestFileData.ts
+++ b/packages/backend/test/TestFileData.ts
@@ -124,23 +124,18 @@ test('inserting', async () => {
 
 test('file media', async () => {
   const file01 = await data.download({
-    workspace: 'main',
     location: 'file01.txt'
   })
   if (file01.type !== 'buffer') throw 'Buffer expected'
   assert.is(file01.buffer.toString(), 'content01')
   const uploadPath = await data.upload({
-    workspace: 'main',
-    root: 'data',
-    path: 'file04.txt',
+    fileLocation: 'file04.txt',
     buffer: Buffer.from('content04')
   })
-  const file04 = await data.download({workspace: 'main', location: uploadPath})
+  const file04 = await data.download({location: uploadPath})
   if (file04.type !== 'buffer') throw 'Buffer expected'
   assert.is(file04.buffer.toString(), 'content04')
-  const [, err1] = await outcome(
-    data.download({workspace: 'main', location: '../out.txt'})
-  )
+  const [, err1] = await outcome(data.download({location: '../out.txt'}))
   assert.is((err1 as ErrorWithCode).code, 401)
 })
 

--- a/packages/backend/test/TestFileData.ts
+++ b/packages/backend/test/TestFileData.ts
@@ -124,12 +124,12 @@ test('inserting', async () => {
 
 test('file media', async () => {
   const file01 = await data.download({
-    location: 'file01.txt'
+    location: 'files/file01.txt'
   })
   if (file01.type !== 'buffer') throw 'Buffer expected'
   assert.is(file01.buffer.toString(), 'content01')
   const uploadPath = await data.upload({
-    fileLocation: 'file04.txt',
+    fileLocation: 'files/file04.txt',
     buffer: Buffer.from('content04')
   })
   const file04 = await data.download({location: uploadPath})

--- a/packages/core/src/Hub.ts
+++ b/packages/core/src/Hub.ts
@@ -68,8 +68,11 @@ export namespace Hub {
     width?: number
     height?: number
   }
+  export type MediaUploadParams = {
+    buffer: ArrayBuffer
+    fileLocation: string
+  }
   export type DownloadParams = {
-    workspace: string
     location: string
   }
   export type Download =

--- a/packages/core/src/Workspace.ts
+++ b/packages/core/src/Workspace.ts
@@ -21,6 +21,8 @@ export type WorkspaceOptions<T = any> = {
   typeNamespace?: string
   /** The directory where media files are placed in case a file backend is used */
   mediaDir?: string
+  /* Rewrite media urls based on their location */
+  mediaUrl?: (location: string) => string
   /** The main theme color used in the dashboard */
   color?: string
   /** A react component used to preview an entry in the dashboard */

--- a/packages/core/src/Workspace.ts
+++ b/packages/core/src/Workspace.ts
@@ -21,8 +21,8 @@ export type WorkspaceOptions<T = any> = {
   typeNamespace?: string
   /** The directory where media files are placed in case a file backend is used */
   mediaDir?: string
-  /* Rewrite media urls based on their location */
-  mediaUrl?: (location: string) => string
+  /* Todo: Rewrite media urls based on their location */
+  // mediaUrl?: (location: string) => string
   /** The main theme color used in the dashboard */
   color?: string
   /** A react component used to preview an entry in the dashboard */

--- a/packages/core/src/util/Paths.ts
+++ b/packages/core/src/util/Paths.ts
@@ -35,11 +35,11 @@ function normalizeArray(parts: Array<string>, allowAboveRoot: boolean) {
   return res
 }
 
-function isAbsolute(path: string) {
+export function isAbsolute(path: string) {
   return path.charAt(0) === '/'
 }
 
-function normalize(path: string) {
+export function normalize(path: string) {
   var absolute = isAbsolute(path),
     trailingSlash = path && path[path.length - 1] === '/'
 

--- a/packages/core/src/util/Paths.ts
+++ b/packages/core/src/util/Paths.ts
@@ -9,6 +9,53 @@ function posixSplitPath(filename: string) {
   return splitPathRe.exec(filename)!.slice(1)
 }
 
+// resolves . and .. elements in a path array with directory names there
+// must be no slashes or device names (c:\) in the array
+// (so also no leading and trailing slashes - it does not distinguish
+// relative and absolute paths)
+function normalizeArray(parts: Array<string>, allowAboveRoot: boolean) {
+  var res = []
+  for (var i = 0; i < parts.length; i++) {
+    var p = parts[i]
+
+    // ignore empty parts
+    if (!p || p === '.') continue
+
+    if (p === '..') {
+      if (res.length && res[res.length - 1] !== '..') {
+        res.pop()
+      } else if (allowAboveRoot) {
+        res.push('..')
+      }
+    } else {
+      res.push(p)
+    }
+  }
+
+  return res
+}
+
+function isAbsolute(path: string) {
+  return path.charAt(0) === '/'
+}
+
+function normalize(path: string) {
+  var absolute = isAbsolute(path),
+    trailingSlash = path && path[path.length - 1] === '/'
+
+  // Normalize the path
+  path = normalizeArray(path.split('/'), !absolute).join('/')
+
+  if (!path && !absolute) {
+    path = '.'
+  }
+  if (path && trailingSlash) {
+    path += '/'
+  }
+
+  return (absolute ? '/' : '') + path
+}
+
 export function dirname(path: string) {
   var result = posixSplitPath(path),
     root = result[0],
@@ -36,12 +83,12 @@ export function basename(path: string, ext?: string) {
   return f
 }
 
-export function join(...args: Array<string>) {
+export function join(...args: Array<string | undefined>) {
   var path = ''
   for (var i = 0; i < args.length; i++) {
     var segment = args[i]
     if (typeof segment !== 'string') {
-      throw new TypeError('Arguments to path.join must be strings')
+      continue
     }
     if (segment) {
       if (!path) {
@@ -51,7 +98,7 @@ export function join(...args: Array<string>) {
       }
     }
   }
-  return path
+  return normalize(path)
 }
 
 export function extname(path: string) {

--- a/packages/core/src/util/Urls.ts
+++ b/packages/core/src/util/Urls.ts
@@ -1,11 +1,12 @@
-export function joinPaths(...paths: Array<string>) {
+export function joinPaths(...paths: Array<string | undefined>) {
   return paths
+    .filter(Boolean)
     .map((part, i) => {
       let start = 0,
         end = undefined
-      if (i < paths.length - 1 && part.endsWith('/')) end = -1
-      if (i > 0 && part.startsWith('/')) start = 1
-      return part.slice(start, end)
+      if (i < paths.length - 1 && part!.endsWith('/')) end = -1
+      if (i > 0 && part!.startsWith('/')) start = 1
+      return part!.slice(start, end)
     })
     .join('/')
 }


### PR DESCRIPTION
We'll need to support a way to form urls for each type of link (entry, image, file). Currently thinking of:

````ts
TypeConfig.entryUrl(path: string, parents: Array<string>): string
WorkspaceConfig.mediaUrl(location: string): string
````