### PR TITLE
Save root of parentless entries

### DIFF
--- a/packages/backend/src/Storage.ts
+++ b/packages/backend/src/Storage.ts
@@ -55,6 +55,7 @@ export namespace Storage {
         index: alinea.index,
         i18n: alinea.i18n
       }
+      if (!entry.alinea.parent) meta.root = entry.alinea.root
       changes.write.push({
         id: entry.id,
         file,

--- a/packages/core/src/Entry.ts
+++ b/packages/core/src/Entry.ts
@@ -11,6 +11,9 @@ export enum EntryStatus {
 }
 
 export interface EntryMetaRaw {
+  // In case this entry has no parent we'll keep a reference to which root it
+  // belongs to
+  root?: string
   // These fields are stored on disk when using file data
   index: string
   i18n?: {id: string}


### PR DESCRIPTION
Just in case content gets mixed up in the same directory we keep a reference to which root entries belong to