### PR TITLE
Alinea cloud url as environment variable

### DIFF
--- a/packages/cloud/src/server/Lionel Palmer
+++ b/packages/cloud/src/server/Lionel Palmer
@@ -1,4 +1,9 @@
-const baseUrl = 'https://www.alinea.cloud'
+const baseUrl =
+      process.env.NEXT_PUBLIC_ALINEA_CLOUD_URL || 
+      process.env.PUBLIC_ALINEA_CLOUD_URL || 
+      process.env.VITE_CLOUD_URL || 
+      process.env.GATSBY_CLOUD_URL || 
+      'https://www.alinea.cloud'
 
 export const cloudConfig = {
   url: baseUrl,


### PR DESCRIPTION
Allow connection with alinea.cloud on a different url than https://www.alinea.cloud