### PR TITLE
Return non-null match with `loose` set to `true`

### DIFF
--- a/packages/dashboard/src/hook/UseLocale.ts
+++ b/packages/dashboard/src/hook/UseLocale.ts
@@ -8,7 +8,7 @@ const nav = dashboardNav({})
 
 export function useLocale(): string | undefined {
   const root = useRoot()
-  const [match] = outcome(() => useMatch(nav.matchRoot))
+  const [match] = outcome(() => useMatch(nav.matchRoot, true))
   return useMemo(() => {
     const {i18n} = root
     if (!i18n) return


### PR DESCRIPTION
With the `loose` set to `false`, `useMatch` always returns a `null` match breaking i18n switching and editing.

Fixes #294.