### PR TITLE
Fix querying page typo in docs

### DIFF
--- a/apps/web/content/pages/docs/content/pages.json
+++ b/apps/web/content/pages/docs/content/pages.json
@@ -1,7 +1,7 @@
 {
   "id": "28hxVNf3JO9raYJ1HVQ6XgDX9pW",
   "type": "Doc",
-  "title": "Quering content",
+  "title": "Querying content",
   "body": [
     {
       "type": "heading",
@@ -10,7 +10,7 @@
       "content": [
         {
           "type": "text",
-          "text": "Quering content"
+          "text": "Querying content"
         }
       ]
     },


### PR DESCRIPTION
There's was a typo in the docs. It says "Quering" when it should say "Querying". This PR addresses this.

<img width="706" alt="Screenshot 2023-07-28 at 3 15 27 PM" src="https://github.com/alineacms/alinea/assets/5762581/b416c79e-3f8e-48b1-b1fb-e0378740464d">
