### PR TITLE
Allow dynamically setting the location and condition options of links

### DIFF
--- a/apps/dev/src/schema/example/LinkFields.tsx
+++ b/apps/dev/src/schema/example/LinkFields.tsx
@@ -5,9 +5,18 @@ export const LinkFields = Config.document('Link fields', {
     externalLink: Field.url('External link'),
     entry: Field.entry('Internal link'),
     entryWithCondition: Field.entry('With condition', {
-      help: `Show only entries of type Fields in the main workspace`,
-      location: {workspace: 'primary', root: 'fields'},
+      help: `Show only entries of type BasicFields`,
       condition: {_type: 'BasicFields'}
+    }),
+    entryWithLocation: Field.entry('With location', {
+      async location({graph}) {
+        const subFolder = await graph.get({path: 'sub-folder'})
+        return {
+          parentId: subFolder._id,
+          workspace: subFolder._workspace,
+          root: subFolder._root
+        }
+      }
     }),
     linkMultiple: Field.link.multiple('Mixed links, multiple'),
     image: Field.image('Image link'),

--- a/src/field/link/LinkField.view.tsx
+++ b/src/field/link/LinkField.view.tsx
@@ -36,6 +36,7 @@ import {useField} from 'alinea/dashboard/editor/UseField'
 import {useGraph} from 'alinea/dashboard/hook/UseGraph'
 import {useLocale} from 'alinea/dashboard/hook/UseLocale'
 import {useNav} from 'alinea/dashboard/hook/UseNav'
+import {SuspenseBoundary} from 'alinea/dashboard/util/SuspenseBoundary'
 import {Create} from 'alinea/dashboard/view/Create'
 import {IconButton} from 'alinea/dashboard/view/IconButton'
 import {InputLabel} from 'alinea/dashboard/view/InputLabel'
@@ -80,13 +81,15 @@ export function SingleLinkInput<Row>({field}: LinkInputProps<Row>) {
   return (
     <>
       {PickerView && (
-        <PickerView
-          type={pickFrom!}
-          options={picker.options}
-          selection={[value]}
-          onConfirm={handleConfirm}
-          onCancel={() => setPickFrom(undefined)}
-        />
+        <SuspenseBoundary name="picker">
+          <PickerView
+            type={pickFrom!}
+            options={picker.options}
+            selection={[value]}
+            onConfirm={handleConfirm}
+            onCancel={() => setPickFrom(undefined)}
+          />
+        </SuspenseBoundary>
       )}
       <InputLabel {...options} error={error} icon={IcRoundLink}>
         <div className={styles.root()}>

--- a/src/picker/entry/EntryPicker.ts
+++ b/src/picker/entry/EntryPicker.ts
@@ -1,7 +1,6 @@
-import {Entry} from 'alinea/core/Entry'
 import {EntryFields} from 'alinea/core/EntryFields'
 import {Filter} from 'alinea/core/Filter'
-import {Projection} from 'alinea/core/Graph'
+import {Graph, Projection} from 'alinea/core/Graph'
 import {Label} from 'alinea/core/Label'
 import {Picker} from 'alinea/core/Picker'
 import {Reference} from 'alinea/core/Reference'
@@ -12,14 +11,34 @@ import {Type, type} from 'alinea/core/Type'
 import {assign, keys} from 'alinea/core/util/Objects'
 import {EntryReference} from './EntryReference.js'
 
+export interface EditorInfo {
+  graph: Graph
+  entry: {
+    id: string
+    type: string
+    workspace: string
+    root: string
+    parentId: string | null
+    locale: string | null
+  }
+}
+
+export interface EditorLocation {
+  parentId?: string
+  workspace: string
+  root: string
+}
+
+type DynamicOption<T> = T | ((info: EditorInfo) => T | Promise<T>)
+
 export interface EntryPickerConditions {
-  /** Show entries from a specific workspace/root */
-  location?: {workspace: string; root: string}
-  /** Choose from direct children of the currently edited entry */
+  /** Choose from a flat list of direct children of the currently edited entry */
   pickChildren?: boolean
-  /** Filter entries by a condition */
-  condition?: Filter<EntryFields & Entry>
-  /** Enable entry picker navigation */
+  /** Set the initial location in which the entry picker is opened */
+  location?: DynamicOption<EditorLocation>
+  /** Filter entries by a condition, this results in a flat list of options */
+  condition?: DynamicOption<Filter<EntryFields>>
+  /** @internal Enable entry picker navigation */
   enableNavigation?: boolean
 }
 


### PR DESCRIPTION
This allows the following example to work:

````tsx
export const LinkFields = Config.document('Link fields', {
  fields: {
    entryDynamicCondition: Field.entry('With dynamic condition', {
      async condition({graph, entry}) {
        const {parents} = await graph.get({
          id: entry.id,
          select: {parents: Query.parents({filter: {_type: 'Examples'}})}
        })
        return {_parentId: parents[0]._id}
      }
    }),
    entryWithLocation: Field.entry('With location', {
      async location({graph}) {
        const subFolder = await graph.get({path: 'sub-folder'})
        return {
          parentId: subFolder._id,
          workspace: subFolder._workspace,
          root: subFolder._root
        }
      }
    })
  }
})
````