### PR TITLE
Add preview property to disable the preview window in a channel

### DIFF
--- a/src/core/Type.ts
+++ b/src/core/Type.ts
@@ -8,6 +8,7 @@ import {getType, hasType, HasType, internalType} from './Internal.js'
 import {Label} from './Label.js'
 import {SummaryProps} from './media/Summary.js'
 import {OrderBy} from './OrderBy.js'
+import {Preview} from './Preview.js'
 import {section, Section} from './Section.js'
 import {RecordShape} from './shape/RecordShape.js'
 import {isValidIdentifier} from './util/Identifiers.js'
@@ -91,6 +92,10 @@ export namespace Type {
     return res
   }
 
+  export function preview(type: Type): Preview | undefined {
+    return getType(type).preview
+  }
+
   const TypeOptions = cito.object({
     view: cito.string.optional,
     summaryRow: cito.string.optional,
@@ -167,6 +172,8 @@ export interface TypeConfig<Definition> {
   insertOrder?: 'first' | 'last' | 'free'
 
   entryUrl?: (meta: EntryUrlMeta) => string
+
+  preview?: Preview
 }
 
 export interface TypeInternal extends TypeConfig<FieldsDefinition> {

--- a/src/dashboard/atoms/EntryEditorAtoms.ts
+++ b/src/dashboard/atoms/EntryEditorAtoms.ts
@@ -759,6 +759,7 @@ export function createEntryEditor(entryData: EntryData) {
   const isLoading = edits.isLoading
 
   const preview =
+    Type.preview(type) ??
     Root.preview(
       config.workspaces[activeVersion.workspace][activeVersion.root]
     ) ??


### PR DESCRIPTION
Added a preview property to the schema TypeConfig inside `Config.type` to disable the preview on schema level:

apps/dev/scr/schema/Examples.tsx:
```typescript
import {Config} from 'alinea'
import {Entry} from 'alinea/core'
import * as examples from './example'

export const Examples = Config.document('Examples', {
  contains: Object.values(examples),
  orderChildrenBy: {asc: Entry.title},
  fields: {},
  preview: false // This one is added to disable the preview when the preview is enabled on workspace or root level
})

```