### PR TITLE
chore: fix copy on paste block label

### DIFF
--- a/src/field/list/ListField.view.tsx
+++ b/src/field/list/ListField.view.tsx
@@ -334,7 +334,7 @@ function pasteBlockLabel(
   items: Array<ListFieldTypeItem>
 ): string {
   const item = items.find(item => item.id === row._type)
-  return item ? `Paste ${item.label} block` : 'Paste block'
+  return item ? `Paste ${item.label}` : 'Paste block'
 }
 
 interface ListFieldCreateActionsProps {


### PR DESCRIPTION
removed duplicate block string